### PR TITLE
Made the example service used in the test application public

### DIFF
--- a/test/app/AppKernel.php
+++ b/test/app/AppKernel.php
@@ -12,6 +12,7 @@
 namespace Lakion\ApiTestCase\Test\App;
 
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Lakion\ApiTestCase\Test\Service\ThirdPartyApiClient;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -67,9 +68,10 @@ class AppKernel extends Kernel
                 ),
             ));
 
-            $container->setDefinition('app.third_party_api_client', new Definition(
-                'Lakion\ApiTestCase\Test\Service\ThirdPartyApiClient'
-            ));
+            $apiClientDefinition = new Definition(ThirdPartyApiClient::class);
+            $apiClientDefinition->setPublic(true);
+
+            $container->setDefinition('app.third_party_api_client', $apiClientDefinition);
         });
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | n/a
| License         | MIT

Made the `app.third_party_api_client` service used in the test application public, so it can be retrieved from the container in the controllers.

Another approach would be to inject it in the controller, but I think think it is ok for this library's purpose to just fetch it from the container.